### PR TITLE
feat DB스케줄러, 혼잡도순, 가나다순 기능 추가

### DIFF
--- a/SeoulGuide/src/main/java/com/seoul/guide/density/Controller/DensityController.java
+++ b/SeoulGuide/src/main/java/com/seoul/guide/density/Controller/DensityController.java
@@ -1,27 +1,104 @@
 package com.seoul.guide.density.Controller;
 
+import java.io.StringReader;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import com.seoul.guide.density.DTO.CityDataResponse;
 import com.seoul.guide.density.DTO.DensityDTO;
 import com.seoul.guide.density.Service.DensityService;
 
+//DensityController
 @Controller
 public class DensityController {
-    @Autowired
-    DensityService densityService;
+	@Autowired
+	DensityService densityService;
 
-    @RequestMapping("/density")
-    public String getDensityInfo(Model model) throws Exception {
+	private ExecutorService executorService = Executors.newFixedThreadPool(100);
+
+	@RequestMapping("/density")
+	public String getDensityInfo(Model model, @RequestParam(value = "sort", defaultValue = "default") String sort) throws Exception {
+	    List<DensityDTO> densityList;
+	    if ("dense_lvl".equals(sort)) {
+	        densityList = densityService.selectAllDensityOrderByDenseLvl();
+	    } else if ("name".equals(sort)) {
+	        densityList = densityService.selectAllDensityOrderByName();
+	    } else {
+	        densityList = densityService.selectAllDensity();
+	    }
+	    model.addAttribute("densityList", densityList);
+	    model.addAttribute("sort", sort); // 현재 선택된 정렬 옵션을 모델에 추가
+	    return "density/density";
+	}
+
+
+    @Scheduled(fixedRate = 600000) // 10분마다 실행
+    public void updateData() throws Exception {
+    	
+    	// 현재 시간
+        LocalTime now = LocalTime.now();
+        
+    	System.out.println("업데이트 완료! DB갱신 " + now);
         List<DensityDTO> densityList = densityService.selectAllDensity();
-        model.addAttribute("densityList", densityList);
-        return "density/density";
-    }
-    
 
+        List<CompletableFuture<Void>> futureList = new ArrayList<>();
+
+        for(DensityDTO densityDTO : densityList){
+            CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+                RestTemplate restTemplate = new RestTemplate();
+                UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl("http://openapi.seoul.go.kr:8088/676c5a574e67636837346f4a627464/xml/citydata/1/5/")
+                        .path(densityDTO.getDens_name());
+
+                ResponseEntity<String> responseEntity = restTemplate.exchange(builder.build().toUri(), HttpMethod.GET, null, String.class);
+                HttpStatus statusCode = responseEntity.getStatusCode();
+                if (statusCode == HttpStatus.OK) {
+                    String xmlResponse = responseEntity.getBody();
+                    try {
+                        JAXBContext jaxbContext = JAXBContext.newInstance(CityDataResponse.class);
+                        Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+                        StringReader reader = new StringReader(xmlResponse);
+                        
+                        CityDataResponse cityDataResponse = (CityDataResponse) jaxbUnmarshaller.unmarshal(reader);
+
+                        if (cityDataResponse != null && cityDataResponse.getCityData() != null) {
+                            try {
+                                densityDTO.setDense_lvl(cityDataResponse.getCityData().getOuterLivePopulationStatus().getInnerLivePopulationStatus().getAreaCongestLevel());
+                                densityDTO.setDense_msg(cityDataResponse.getCityData().getOuterLivePopulationStatus().getInnerLivePopulationStatus().getAreaCongestMessage());
+                                densityService.updateDensity(densityDTO); // DB에 업데이트
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                            }
+                        }
+
+                        
+                    } catch (JAXBException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }, executorService);
+            futureList.add(future);
+        }
+
+        CompletableFuture.allOf(futureList.toArray(new CompletableFuture[0])).join();
+    }
 }

--- a/SeoulGuide/src/main/java/com/seoul/guide/density/DAO/DensityDAO.java
+++ b/SeoulGuide/src/main/java/com/seoul/guide/density/DAO/DensityDAO.java
@@ -1,8 +1,13 @@
 package com.seoul.guide.density.DAO;
 
-import com.seoul.guide.density.DTO.DensityDTO;
 import java.util.List;
+
+import com.seoul.guide.density.DTO.DensityDTO;
 
 public interface DensityDAO {
     List<DensityDTO> selectAllDensity() throws Exception;
+    void updateDensity(DensityDTO densityDTO) throws Exception;
+    List<DensityDTO> selectAllDensityOrderByDenseLvl() throws Exception;
+    List<DensityDTO> selectAllDensityOrderByName() throws Exception;
+    List<DensityDTO> selectAllDensityUnsorted() throws Exception; // 추가
 }

--- a/SeoulGuide/src/main/java/com/seoul/guide/density/DAO/DensityDAOImpl.java
+++ b/SeoulGuide/src/main/java/com/seoul/guide/density/DAO/DensityDAOImpl.java
@@ -1,18 +1,42 @@
 package com.seoul.guide.density.DAO;
 
-import com.seoul.guide.density.DTO.DensityDTO;
-import org.mybatis.spring.SqlSessionTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Repository;
 import java.util.List;
 
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import com.seoul.guide.density.DTO.DensityDTO;
+
+//DensityDAOImpl
 @Repository
 public class DensityDAOImpl implements DensityDAO {
     @Autowired
-    private SqlSessionTemplate sqlSession;
+    SqlSession sqlSession;
 
     @Override
     public List<DensityDTO> selectAllDensity() throws Exception {
         return sqlSession.selectList("mapper.density.selectAllDensity");
     }
+    
+    @Override
+    public void updateDensity(DensityDTO densityDTO) throws Exception {
+        sqlSession.update("mapper.density.updateDensity", densityDTO);
+    }
+
+    @Override
+    public List<DensityDTO> selectAllDensityOrderByDenseLvl() throws Exception {
+        return sqlSession.selectList("mapper.density.selectAllDensityOrderByDenseLvl");
+    }
+
+    @Override
+    public List<DensityDTO> selectAllDensityOrderByName() throws Exception {
+        return sqlSession.selectList("mapper.density.selectAllDensityOrderByName");
+    }
+
+    @Override
+    public List<DensityDTO> selectAllDensityUnsorted() throws Exception {
+        return sqlSession.selectList("mapper.density.selectAllDensityUnsorted"); // 추가
+    }
 }
+

--- a/SeoulGuide/src/main/java/com/seoul/guide/density/DTO/CityDataResponse.java
+++ b/SeoulGuide/src/main/java/com/seoul/guide/density/DTO/CityDataResponse.java
@@ -17,6 +17,8 @@ public class CityDataResponse {
 
     @XmlElement(name = "CITYDATA")
     private CityData cityData;
+    
+    private String densName;
 
     // getter, setter ...
     public int getListTotalCount() {
@@ -34,6 +36,13 @@ public class CityDataResponse {
 	public void setCityData(CityData cityData) {
 		this.cityData = cityData;
 	}
+	
+	public String getDensName() {
+        return densName;
+    }
 
+    public void setDensName(String densName) {
+        this.densName = densName;
+    }
     
 }

--- a/SeoulGuide/src/main/java/com/seoul/guide/density/DTO/DensityDTO.java
+++ b/SeoulGuide/src/main/java/com/seoul/guide/density/DTO/DensityDTO.java
@@ -2,6 +2,7 @@ package com.seoul.guide.density.DTO;
 
 import java.io.Serializable;
 
+//DensityDTO
 public class DensityDTO implements Serializable {
     private String dens_name;
     private String dense_lvl;

--- a/SeoulGuide/src/main/java/com/seoul/guide/density/Service/DensityService.java
+++ b/SeoulGuide/src/main/java/com/seoul/guide/density/Service/DensityService.java
@@ -1,9 +1,15 @@
 // DensityService.java
 package com.seoul.guide.density.Service;
 
-import com.seoul.guide.density.DTO.DensityDTO;
 import java.util.List;
+import com.seoul.guide.density.DTO.DensityDTO;
+
 
 public interface DensityService {
     List<DensityDTO> selectAllDensity() throws Exception;
+    void updateDensity(DensityDTO densityDTO) throws Exception;
+
+    List<DensityDTO> selectAllDensityOrderByDenseLvl() throws Exception;
+    List<DensityDTO> selectAllDensityOrderByName() throws Exception;
+    List<DensityDTO> selectAllDensityUnsorted() throws Exception; // 추가
 }

--- a/SeoulGuide/src/main/java/com/seoul/guide/density/Service/DensityServiceImpl.java
+++ b/SeoulGuide/src/main/java/com/seoul/guide/density/Service/DensityServiceImpl.java
@@ -1,19 +1,56 @@
 // DensityServiceImpl.java
 package com.seoul.guide.density.Service;
 
-import com.seoul.guide.density.DAO.DensityDAO;
-import com.seoul.guide.density.DTO.DensityDTO;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import java.util.List;
 
+import com.seoul.guide.density.DAO.DensityDAO;
+import com.seoul.guide.density.DTO.DensityDTO;
+
+//DensityServiceImpl
 @Service
 public class DensityServiceImpl implements DensityService {
     @Autowired
     DensityDAO densityDAO;
 
+    private static final List<String> ORDERED_DENSE_LVL = Arrays.asList("여유", "보통", "약간 붐빔", "붐빔");
+
+    
     @Override
     public List<DensityDTO> selectAllDensity() throws Exception {
         return densityDAO.selectAllDensity();
+    }
+
+    @Override
+    public void updateDensity(DensityDTO densityDTO) throws Exception {
+        densityDAO.updateDensity(densityDTO);
+    }
+
+    //혼잡도순 정렬을 위한 역순정렬 코드 
+    @Override
+    public List<DensityDTO> selectAllDensityOrderByDenseLvl() throws Exception {
+        return densityDAO.selectAllDensity()
+            .stream()
+            .sorted((d1, d2) -> ORDERED_DENSE_LVL.indexOf(d2.getDense_lvl()) - ORDERED_DENSE_LVL.indexOf(d1.getDense_lvl())) // 순서 반전
+            .collect(Collectors.toList());
+    }
+
+
+
+
+
+
+    @Override
+    public List<DensityDTO> selectAllDensityOrderByName() throws Exception {
+        return densityDAO.selectAllDensityOrderByName();
+    }
+
+    @Override
+    public List<DensityDTO> selectAllDensityUnsorted() throws Exception {
+        return densityDAO.selectAllDensityUnsorted(); // 추가
     }
 }

--- a/SeoulGuide/src/main/resources/config/context-jdbc.xml
+++ b/SeoulGuide/src/main/resources/config/context-jdbc.xml
@@ -8,10 +8,10 @@
 			<value>com.mysql.cj.jdbc.Driver</value>
 		</property>
 		<property name="url">
-			<value>jdbc:mysql://localhost:3307/seoul</value>
+			<value>jdbc:mysql://localhost:3307/kosta</value>
 		</property>
 		<property name="username">
-			<value>kosta</value>
+			<value>root</value>
 		</property>
 		<property name="password">
 			<value>1234</value>

--- a/SeoulGuide/src/main/resources/sql/density.xml
+++ b/SeoulGuide/src/main/resources/sql/density.xml
@@ -3,9 +3,48 @@
 PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="mapper.density">
-    <select id="selectAllDensity" resultType="com.seoul.guide.density.DTO.DensityDTO">
+	<select id="selectAllDensity"
+		resultType="com.seoul.guide.density.DTO.DensityDTO">
         <![CDATA[
             select * from density
         ]]>
-    </select>
+	</select>
+
+	<select id="selectAllDensityOrderByDenseLvl"
+		resultType="com.seoul.guide.density.DTO.DensityDTO">
+		SELECT * FROM density
+		ORDER BY CASE
+		WHEN dense_lvl = '여유' THEN 1
+		WHEN dense_lvl = '보통' THEN 2
+		WHEN dense_lvl = '약간 붐빔' THEN 3
+		WHEN dense_lvl = '붐빔' THEN 4
+		ELSE 5
+		END DESC
+	</select>
+
+
+	<select id="selectAllDensityOrderByName"
+		resultType="com.seoul.guide.density.DTO.DensityDTO">
+        <![CDATA[
+            select * from density order by dens_name asc
+        ]]>
+	</select>
+
+	<update id="updateDensity">
+        <![CDATA[
+            update density
+            set dense_lvl = #{dense_lvl}, dense_msg = #{dense_msg}
+            where dens_name = #{dens_name}
+        ]]>
+	</update>
+
+	<select id="selectAllDensityUnsorted"
+		resultType="com.seoul.guide.density.DTO.DensityDTO">
+    <![CDATA[
+        select * from density
+    ]]>
+	</select>
+
+
 </mapper>
+

--- a/SeoulGuide/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/SeoulGuide/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans
-	xmlns="http://www.springframework.org/schema/mvc"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:beans="http://www.springframework.org/schema/beans"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
-		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
+    xmlns="http://www.springframework.org/schema/mvc"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:beans="http://www.springframework.org/schema/beans"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:task="http://www.springframework.org/schema/task"
+    xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd">
+
+    <task:annotation-driven executor="myExecutor" scheduler="myScheduler"/>
+    <task:executor id="myExecutor" pool-size="5"/>
+    <task:scheduler id="myScheduler" pool-size="10"/>
 
 	<!-- DispatcherServlet Context: defines this servlet's request-processing 
 		infrastructure -->

--- a/SeoulGuide/src/main/webapp/WEB-INF/views/density/density.jsp
+++ b/SeoulGuide/src/main/webapp/WEB-INF/views/density/density.jsp
@@ -16,6 +16,27 @@
 </head>
 <body>
 	<h1>Density Information</h1>
+
+	<!-- Sort By -->
+	<form id="sortForm" method="get">
+		<select id="sortSelect" name="sort">
+			<option value="default" ${'default' eq sort ? 'selected' : ''}>기본</option>
+			<option value="dense_lvl" ${'dense_lvl' eq sort ? 'selected' : ''}>혼잡도순</option>
+			<option value="name" ${'name' eq sort ? 'selected' : ''}>가나다순</option>
+		</select>
+	</form>
+
+	<script>
+		$(document).ready(function() {
+			$('#sortSelect').change(function() {
+				$('#sortForm').submit();
+			});
+		});
+	</script>
+
+
+
+
 	<div class="container">
 		<div class="row">
 			<c:forEach var="density" items="${densityList}">


### PR DESCRIPTION
- 10분마다 API로 데이터 받아와서 DB 업데이트 해주는 스케줄링 코드 추가
- API 받아올 때 병렬처리를 위해 CPU스레드 수 이상의 작업처리 요청 코드 추가
- 교통정보(density) 페이지 내의 관광지를 혼잡도순, 가나다순으로 볼 수 있도록 추가

